### PR TITLE
Fix install errors when installing with Sentry 9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as readme_file:
 
 install_requires = [
     'sentry>=7.0.0',
-    'requests<2.19.0,>=2.18.4',
+    'requests<3.0.0'
 ]
 
 tests_require = [


### PR DESCRIPTION
Sentry 9.1 bumped its `requests` requirement to a newer version than specified in this plugins' `setup.py` file. This means that when installing this plugin with Sentry 9.1 the `requests` package gets downgraded, and causes a number of errors when running Sentry. Removing the explicit version constraint fixes this, and allows the plugin to work with Sentry 9.1