### PR TITLE
fix: oidc configure view for sentry 24.8.0

### DIFF
--- a/oidc/provider.py
+++ b/oidc/provider.py
@@ -14,7 +14,7 @@ from .constants import (
     TOKEN_ENDPOINT,
     USERINFO_ENDPOINT,
 )
-from .views import FetchUser, OIDCConfigureView
+from .views import FetchUser, oidc_configure_view
 
 
 class OIDCLogin(OAuth2Login):
@@ -64,7 +64,7 @@ class OIDCProvider(OAuth2Provider):
         return CLIENT_SECRET
 
     def get_configure_view(self):
-        return OIDCConfigureView.as_view()
+        return oidc_configure_view
 
     def get_auth_pipeline(self):
         return [


### PR DESCRIPTION
This currently errors out with
`ImportError: cannot import name 'ConfigureView' from 'sentry.auth.view'` because of https://github.com/getsentry/sentry/commit/6ea317f564734cd216e85d8c7ba270ae4cc85b36