### PR TITLE
Fix compatibility with Sentry 25.3.0

### DIFF
--- a/oidc/apps.py
+++ b/oidc/apps.py
@@ -1,3 +1,5 @@
+from inspect import signature
+
 from django.apps import AppConfig
 
 
@@ -9,4 +11,10 @@ class Config(AppConfig):
 
         from .provider import OIDCProvider
 
-        auth.register("oidc", OIDCProvider)
+        # In Sentry 25.3.0, the signature of `ProviderManager.register()` changed:
+        # Instead of providing the key as a parameter, it is now expected to be a
+        # property of the provider class.
+        if len(signature(auth.register).parameters) == 1:
+            auth.register(OIDCProvider)
+        else:
+            auth.register("oidc", OIDCProvider)

--- a/oidc/provider.py
+++ b/oidc/provider.py
@@ -47,6 +47,7 @@ class OIDCLogin(OAuth2Login):
 
 class OIDCProvider(OAuth2Provider):
     name = ISSUER
+    key = "oidc"
 
     def __init__(self, domain=None, domains=None, version=None, **config):
         if domain:


### PR DESCRIPTION
In Sentry 25.3.0, the signature for `ProviderManager.auth()` has changed to only take one instead of two arguments. (see https://github.com/getsentry/sentry/pull/85597)

This leads to an error when using this plugin because it still calls `register()` with two arguments.

I've added a check for this, so this plugin remains compatbile with both the old and the new Sentry versions.