### PR TITLE
Bump version and sentry dependency 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = deps/sentry
 	url = https://github.com/getsentry/sentry.git
 	# This is here for renovate
-	branch = 24.8.0
+	branch = 25.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry-auth-oidc"
-version = "9.0.0"
+version = "9.0.1"
 description = "OpenID Connect authentication provider for Sentry"
 authors = [
     "Max Wittig <max.wittig@siemens.com>",


### PR DESCRIPTION
Bumps the version to get https://github.com/siemens/sentry-auth-oidc/pull/55 out, and bumps sentry to the version the fix is for.