### PR TITLE
feat: make UserInfo name claim configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,10 @@ Finally, obtain the API keys and the well-known account URL and plug them into y
 
     OIDC_DOMAIN = "https://accounts.google.com"  # e.g. for Google
 
+    # Optional: UserInfo claim to use as Sentry's display name.
+    # Defaults to "name".
+    OIDC_USERINFO_NAME_CLAIM = "name"
+
 The ``OIDC_DOMAIN`` defines where the OIDC configuration is going to be pulled from.
 Basically it specifies the OIDC server and adds the path ``.well-known/openid-configuration`` to it.
 That's where different endpoint paths can be found.

--- a/oidc/constants.py
+++ b/oidc/constants.py
@@ -6,6 +6,7 @@ TOKEN_ENDPOINT = getattr(settings, "OIDC_TOKEN_ENDPOINT", None)
 CLIENT_ID = getattr(settings, "OIDC_CLIENT_ID", None)
 CLIENT_SECRET = getattr(settings, "OIDC_CLIENT_SECRET", None)
 USERINFO_ENDPOINT = getattr(settings, "OIDC_USERINFO_ENDPOINT", None)
+USERINFO_NAME_CLAIM = getattr(settings, "OIDC_USERINFO_NAME_CLAIM", "name")
 SCOPE = getattr(settings, "OIDC_SCOPE", "openid email")
 WELL_KNOWN_SCHEME = "/.well-known/openid-configuration"
 ERR_INVALID_RESPONSE = "Unable to fetch user information from provider.  Please check the log."

--- a/oidc/provider.py
+++ b/oidc/provider.py
@@ -20,6 +20,7 @@ from .constants import (
     SCOPE,
     TOKEN_ENDPOINT,
     USERINFO_ENDPOINT,
+    USERINFO_NAME_CLAIM,
 )
 from .views import FetchUser, oidc_configure_view
 
@@ -123,7 +124,7 @@ class OIDCProvider(OAuth2Provider):
         return {
             "id": user_id,
             "email": user_info.get("email"),
-            "name": user_info.get("name"),
+            "name": user_info.get(USERINFO_NAME_CLAIM),
             "data": self.get_oauth_data(data),
             "email_verified": user_info.get("email_verified"),
         }

--- a/tests/test_provider_unit.py
+++ b/tests/test_provider_unit.py
@@ -1,0 +1,121 @@
+import json
+import sys
+import types
+
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        OIDC_AUTHORIZATION_ENDPOINT="https://example.com/auth",
+        OIDC_CLIENT_ID="client-id",
+        OIDC_CLIENT_SECRET="client-secret",
+        OIDC_TOKEN_ENDPOINT="https://example.com/token",
+        OIDC_USERINFO_ENDPOINT="https://example.com/userinfo",
+        SENTRY_METRICS_SKIP_ALL_INTERNAL=True,
+        SENTRY_METRICS_SKIP_INTERNAL_PREFIXES=[],
+        SENTRY_METRICS_BACKEND="sentry.metrics.dummy.DummyMetricsBackend",
+        SENTRY_METRICS_OPTIONS={},
+        SENTRY_METRICS_PREFIX="sentry",
+        SENTRY_METRICS_SAMPLE_RATE=1.0,
+    )
+
+
+class MigratingIdentityId:
+    def __init__(self, id, legacy_id):
+        self.id = id
+        self.legacy_id = legacy_id
+
+
+class OAuth2Login:
+    def __init__(self, client_id):
+        self.client_id = client_id
+
+    def get_authorize_params(self, state, redirect_uri):
+        return {}
+
+
+class OAuth2Callback:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class OAuth2Provider:
+    def __init__(self, **config):
+        self.config = config
+
+    def get_oauth_data(self, payload):
+        return payload
+
+
+def module(name, **attrs):
+    value = types.ModuleType(name)
+    for key, attr in attrs.items():
+        setattr(value, key, attr)
+    sys.modules[name] = value
+    return value
+
+
+module("sentry", auth=types.SimpleNamespace())
+module("sentry.auth")
+module("sentry.auth.provider", MigratingIdentityId=MigratingIdentityId)
+module("sentry.auth.view", AuthView=object)
+module(
+    "sentry.auth.providers.oauth2",
+    OAuth2Callback=OAuth2Callback,
+    OAuth2Login=OAuth2Login,
+    OAuth2Provider=OAuth2Provider,
+)
+module("sentry.auth.services.auth.model", RpcAuthProvider=object)
+module("sentry.organizations.services.organization.model", RpcOrganization=object)
+module("sentry.plugins.base.response", DeferredResponse=object)
+module("sentry.utils", json=json)
+module("sentry.utils.signing", urlsafe_b64decode=lambda value: value)
+
+from oidc.provider import OIDCProvider
+
+
+def test_build_identity_uses_default_userinfo_name_claim():
+    provider = OIDCProvider(domains=["example.com"])
+    provider.get_user_info = lambda token: {
+        "email": "jsmith@example.com",
+        "name": "John Smith",
+        "email_verified": True,
+    }
+
+    result = provider.build_identity(
+        {
+            "data": {"access_token": "access_token", "token_type": "Bearer"},
+            "user": {
+                "sub": "10769150350006150715113082367",
+                "email": "jsmith@example.com",
+            },
+        }
+    )
+
+    assert result["name"] == "John Smith"
+
+
+def test_build_identity_uses_configured_userinfo_name_claim(monkeypatch):
+    provider = OIDCProvider(domains=["example.com"])
+    monkeypatch.setattr("oidc.provider.USERINFO_NAME_CLAIM", "preferred_username", raising=False)
+    monkeypatch.setattr(
+        provider,
+        "get_user_info",
+        lambda token: {
+            "email": "jsmith@example.com",
+            "preferred_username": "jsmith",
+            "email_verified": True,
+        },
+    )
+
+    result = provider.build_identity(
+        {
+            "data": {"access_token": "access_token", "token_type": "Bearer"},
+            "user": {
+                "sub": "10769150350006150715113082367",
+                "email": "jsmith@example.com",
+            },
+        }
+    )
+
+    assert result["name"] == "jsmith"

--- a/tests/test_provider_unit.py
+++ b/tests/test_provider_unit.py
@@ -1,7 +1,11 @@
 import json
 import sys
 import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib import import_module
 
+import pytest
 from django.conf import settings
 
 if not settings.configured:
@@ -47,6 +51,22 @@ class OAuth2Provider:
         return payload
 
 
+SENTRY_STUB_MODULES = [
+    "sentry",
+    "sentry.auth",
+    "sentry.auth.provider",
+    "sentry.auth.view",
+    "sentry.auth.providers.oauth2",
+    "sentry.auth.services.auth.model",
+    "sentry.organizations.services.organization.model",
+    "sentry.plugins.base.response",
+    "sentry.utils",
+    "sentry.utils.signing",
+]
+OIDC_MODULES = ["oidc.constants", "oidc.views", "oidc.provider"]
+MISSING = object()
+
+
 def module(name, **attrs):
     value = types.ModuleType(name)
     for key, attr in attrs.items():
@@ -55,27 +75,48 @@ def module(name, **attrs):
     return value
 
 
-module("sentry", auth=types.SimpleNamespace())
-module("sentry.auth")
-module("sentry.auth.provider", MigratingIdentityId=MigratingIdentityId)
-module("sentry.auth.view", AuthView=object)
-module(
-    "sentry.auth.providers.oauth2",
-    OAuth2Callback=OAuth2Callback,
-    OAuth2Login=OAuth2Login,
-    OAuth2Provider=OAuth2Provider,
-)
-module("sentry.auth.services.auth.model", RpcAuthProvider=object)
-module("sentry.organizations.services.organization.model", RpcOrganization=object)
-module("sentry.plugins.base.response", DeferredResponse=object)
-module("sentry.utils", json=json)
-module("sentry.utils.signing", urlsafe_b64decode=lambda value: value)
+@contextmanager
+def stubbed_provider_module() -> Iterator[types.ModuleType]:
+    module_names = [*SENTRY_STUB_MODULES, *OIDC_MODULES]
+    previous_modules = {name: sys.modules.get(name, MISSING) for name in module_names}
 
-from oidc.provider import OIDCProvider
+    try:
+        for name in OIDC_MODULES:
+            sys.modules.pop(name, None)
+
+        module("sentry", auth=types.SimpleNamespace())
+        module("sentry.auth")
+        module("sentry.auth.provider", MigratingIdentityId=MigratingIdentityId)
+        module("sentry.auth.view", AuthView=object)
+        module(
+            "sentry.auth.providers.oauth2",
+            OAuth2Callback=OAuth2Callback,
+            OAuth2Login=OAuth2Login,
+            OAuth2Provider=OAuth2Provider,
+        )
+        module("sentry.auth.services.auth.model", RpcAuthProvider=object)
+        module("sentry.organizations.services.organization.model", RpcOrganization=object)
+        module("sentry.plugins.base.response", DeferredResponse=object)
+        module("sentry.utils", json=json)
+        module("sentry.utils.signing", urlsafe_b64decode=lambda value: value)
+
+        yield import_module("oidc.provider")
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
 
 
-def test_build_identity_uses_default_userinfo_name_claim():
-    provider = OIDCProvider(domains=["example.com"])
+@pytest.fixture
+def oidc_provider():
+    with stubbed_provider_module() as provider_module:
+        yield provider_module.OIDCProvider
+
+
+def test_build_identity_uses_default_userinfo_name_claim(oidc_provider):
+    provider = oidc_provider(domains=["example.com"])
     provider.get_user_info = lambda token: {
         "email": "jsmith@example.com",
         "name": "John Smith",
@@ -95,9 +136,10 @@ def test_build_identity_uses_default_userinfo_name_claim():
     assert result["name"] == "John Smith"
 
 
-def test_build_identity_uses_configured_userinfo_name_claim(monkeypatch):
-    provider = OIDCProvider(domains=["example.com"])
-    monkeypatch.setattr("oidc.provider.USERINFO_NAME_CLAIM", "preferred_username", raising=False)
+def test_build_identity_uses_configured_userinfo_name_claim(monkeypatch, oidc_provider):
+    provider = oidc_provider(domains=["example.com"])
+    provider_module = sys.modules["oidc.provider"]
+    monkeypatch.setattr(provider_module, "USERINFO_NAME_CLAIM", "preferred_username", raising=False)
     monkeypatch.setattr(
         provider,
         "get_user_info",


### PR DESCRIPTION
**Description**
Adds OIDC_USERINFO_NAME_CLAIM so deployments can choose which UserInfo claim is used as Sentry’s display name during OIDC login.

By default, behavior is unchanged: the plugin still reads the name claim. Providers that do not populate name, but do expose another stable display identifier such as preferred_username, can now configure:

`OIDC_USERINFO_NAME_CLAIM = "preferred_username"`

This helps avoid new-user login failures in Sentry versions where the account creation path expects the resolved identity name to be a non-null string.

Includes isolated provider unit coverage for:
- default name claim behavior
- configured alternate UserInfo name claim behavior